### PR TITLE
CEM TF Reimplementation

### DIFF
--- a/config/agents.yaml
+++ b/config/agents.yaml
@@ -1,11 +1,13 @@
 agents:
   agent:
     replay_buffer_size: 1000000
+    action_repeat: 1
+    add_observation_noise: False
   mbrl_agent:
-    train_batch_size: 1000000
+    train_batch_size: 5000
     train_interaction_steps: 300
-    episode_length: 150
-    warmup_timesteps: 1000
+    episode_length: 200
+    warmup_timesteps: 5000
     policy: cem_mpc
     model: mlp_ensemble
-    scale_features: False
+    scale_features: True

--- a/config/debug.yaml
+++ b/config/debug.yaml
@@ -1,14 +1,14 @@
 options:
   trainer_options:
-    video_log_frequency: 1
+    video_log_frequency: 10
     log_frequency: 1
-    max_video_length: 40
+    max_video_length: 150
     eval_interaction_steps: 100
-    eval_episode_length: 20
+    eval_episode_length: 10
     training_logger_params:
       fps: 28
   seed: 1
-  train_iterations: 5
+  train_iterations: 90
   agent: mbrl_agent
   environment: MbrlInvertedPendulum
 

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -1,12 +1,12 @@
 models:
   mlp_ensemble:
     ensemble_size: 5
-    n_epochs: 70
-    batch_size: 64
+    n_epochs: 75
+    batch_size: 250
     validation_split: 0.1
     learning_rate: 0.001
     mlp_params:
       n_layers: 2
-      units: 64
+      units: 250
       activation: tf.nn.relu
       dropout_rate: 0.0

--- a/config/policies.yaml
+++ b/config/policies.yaml
@@ -1,9 +1,17 @@
 policies:
   cem_mpc:
-    horizon: 20
-    iterations: 5
+    horizon: 10
+    iterations: 10
     objective: TODOYARDEN
-    smoothing: 0.1
-    n_samples: 500
-    n_elite: 50
-    particles: 10
+    smoothing: 0.0
+    n_samples: 150
+    n_elite: 30
+    particles: 5
+   mppi_mpc:
+    horizon: 10
+    objective: TODOYARDEN
+    n_samples: 1000
+  random_shooting_mpc:
+    horizon: 10
+    objective: TODOYARDEN
+    n_samples: 1000

--- a/simba/environment_utils/mbrl_env.py
+++ b/simba/environment_utils/mbrl_env.py
@@ -6,6 +6,6 @@ class MbrlEnv(gym.Wrapper):
         environment = gym.make(env_name)
         super(MbrlEnv, self).__init__(environment)
 
-    def get_reward(self, obs, acs, next_obs):
+    def get_reward(self, obs, acs, *args, **kwargs):
         raise NotImplementedError
 

--- a/simba/environment_utils/safety_gym.py
+++ b/simba/environment_utils/safety_gym.py
@@ -1,5 +1,6 @@
 import numpy as np
 from simba.environment_utils.mbrl_env import MbrlEnv
+from simba.infrastructure.logging_utils import logger
 
 
 class MbrlSafetyGym(MbrlEnv):
@@ -9,8 +10,8 @@ class MbrlSafetyGym(MbrlEnv):
             self.env.config,
             self.env.obs_space_dict)
 
-    def get_reward(self, obs, _, next_obs):
-        return self._scorer.reward(obs, next_obs)
+    def get_reward(self, obs, acs, *args, **kwargs):
+        return self._scorer.reward(obs, *args, **kwargs)
 
     def reset(self, **kwargs):
         observation = self.env.reset(**kwargs)
@@ -27,10 +28,14 @@ class SafetyGymStateScorer(object):
         self.last_box_observed = False
         self.sensor_offset_table = dict()
         offset = 0
+        observation_space_summary = "Observation space indices are: "
         for k, value in sorted(obs_space_dict.items()):
             k_size = np.prod(value.shape)
             self.sensor_offset_table[k] = slice(offset, offset + k_size)
+            observation_space_summary += \
+                (k + " [" + str(offset) + ", " + str(offset + k_size) + ") " + "\n")
             offset += k_size
+        logger.debug(observation_space_summary)
 
     def reset(self, observation):
         if self.task == 'goal':
@@ -51,7 +56,7 @@ class SafetyGymStateScorer(object):
             dist_goal = self.goal_distance_metric(observations_exp)
             next_dist_goal = self.goal_distance_metric(next_observations_exp)
             dones = np.less_equal(dist_goal, self.goal_size)
-            reward += (dist_goal - next_dist_goal) * self.reward_distance + dones * self.reward_goal
+            reward += -dist_goal * self.reward_distance + dones * self.reward_goal
         # Distance from robot to box
         elif self.task == 'push':
             box_observed = np.any(

--- a/simba/infrastructure/trainer.py
+++ b/simba/infrastructure/trainer.py
@@ -35,7 +35,7 @@ class RLTrainer(object):
                     self.eval_interaction_steps,
                     self.eval_episode_length
                 ), iteration)
-            if self.log_frequency > 0 and iteration % self.video_log_frequency == 0:
+            if self.video_log_frequency > 0 and iteration % self.video_log_frequency == 0:
                 self.log_video(self.agent.render_trajectory(
                     environment=self.environment,
                     policy=self.agent.policy,

--- a/simba/policies/__init__.py
+++ b/simba/policies/__init__.py
@@ -1,2 +1,4 @@
 from simba.policies.cem_mpc import CemMpc
 from simba.policies.random_mpc import RandomMpc
+from simba.policies.mppi_mpc import MppiMpc
+from simba.policies.random_shooting_mpc import RandomShootingMpc

--- a/simba/policies/cem_mpc.py
+++ b/simba/policies/cem_mpc.py
@@ -1,11 +1,10 @@
 import numpy as np
-from scipy.stats import truncnorm
-from gym import spaces as spaces
-from simba.policies.policy import PolicyBase
+import tensorflow as tf
+from simba.policies.mpc_policy import MpcPolicy
 from simba.infrastructure.logging_utils import logger
 
 
-class CemMpc(PolicyBase):
+class CemMpc(MpcPolicy):
     def __init__(self,
                  model,
                  environment,
@@ -16,84 +15,52 @@ class CemMpc(PolicyBase):
                  n_samples,
                  n_elite,
                  particles):
-        super().__init__()
-        self.model = model
-        self.reward = environment.get_reward
-        self.action_space = environment.action_space
-        assert isinstance(self.action_space, spaces.Box), "Expecting only box as action space."
-        self.horizon = horizon
+        super().__init__(
+            model,
+            environment,
+            horizon,
+            objective,
+            n_samples,
+            particles
+        )
         self.iterations = iterations
-        self.objective = self.pets_objective
         self.smoothing = smoothing
-        self.n_samples = n_samples
         self.elite = n_elite
-        self.particles = particles
 
     def generate_action(self, state):
+        return self.do_generate_action(tf.constant(state, dtype=tf.float32)).numpy()
+
+    @tf.function
+    def do_generate_action(self, state):
         lb, ub, mu, sigma = self.sampling_params
-        elite = mu
-        for i in range(self.iterations):
-            # Following instructions from https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.truncnorm
-            # .html
-            action_sequences = truncnorm.rvs(
-                a=(lb - mu) / sigma, b=(ub - mu) / sigma, loc=mu, scale=sigma,
-                size=(self.n_samples, self.horizon, self.action_space.shape[0])
+        action_dim = self.action_space.shape[0]
+        mu = tf.broadcast_to(mu, (self.horizon, action_dim))
+        sigma = tf.broadcast_to(sigma, (self.horizon, action_dim))
+        best_so_far = tf.zeros((action_dim,), dtype=tf.float32)
+        best_so_far_score = -np.inf * tf.ones((), dtype=tf.float32)
+        for _ in tf.range(self.iterations):
+            action_sequences = tf.random.normal(
+                shape=(self.n_samples, self.horizon, action_dim),
+                mean=mu, stddev=sigma
             )
-            # Propagate the same action sequences for #particles to get better statistics estimates.
-            action_sequences_batch = np.tile(action_sequences, (self.particles, 1, 1))
-            trajectories = self.model.simulate_trajectories(
-                np.broadcast_to(state, (action_sequences_batch.shape[0], state.shape[0])), action_sequences_batch)
-            assert np.isfinite(trajectories).all(), "Got a non-finite trajectory."
+            action_sequences = tf.clip_by_value(action_sequences, lb, ub)
+            action_sequences_batch = tf.tile(
+                action_sequences, (self.particles, 1, 1)
+            )
+            trajectories = self.model.unfold_sequences(
+                tf.broadcast_to(state, (action_sequences_batch.shape[0], state.shape[0])), action_sequences_batch
+            )
             cumulative_rewards = self.compute_cumulative_rewards(trajectories, action_sequences_batch)
-            assert np.isfinite(cumulative_rewards.all()), "Got non-finite rewards."
             scores = self.objective(cumulative_rewards)
-            elite = action_sequences[np.argsort(scores)[-self.elite:], ...]
-            elite_mu, elite_sigma = elite.mean(axis=0), elite.std(axis=0)
-            mu = self.smoothing * mu + (1.0 - self.smoothing) * elite_mu
-            sigma = self.smoothing * sigma + (1.0 - self.smoothing) * elite_sigma
-            if np.max(sigma) < 1e-1:
+            elite_scores, elite = tf.nn.top_k(scores, self.elite, sorted=False)
+            best_of_elite = tf.argmax(elite_scores)
+            if tf.greater(elite_scores[best_of_elite], best_so_far_score):
+                best_so_far = action_sequences[elite[best_of_elite], 0, ...]
+            elite_actions = tf.gather(action_sequences, elite, axis=0)
+            mean, variance = tf.nn.moments(elite_actions, axes=0)
+            stddev = tf.sqrt(variance)
+            mu = self.smoothing * mu + (1.0 - self.smoothing) * mean
+            sigma = self.smoothing * sigma + (1.0 - self.smoothing) * stddev
+            if tf.less_equal(tf.reduce_mean(sigma), 0.25):
                 break
-        return elite[0, 0, ...]
-
-    def compute_cumulative_rewards(self, trajectories, action_sequences):
-        cumulative_rewards = np.zeros((trajectories.shape[0],))
-        done_trajectories = np.zeros((trajectories.shape[0]), dtype=bool)
-        for t in range(self.horizon - 1):
-            s_t = trajectories[:, t, ...]
-            s_t_1 = trajectories[:, t + 1, ...]
-            a_t = action_sequences[:, t, ...]
-            reward, dones = self.reward(s_t, a_t, s_t_1)
-            done_trajectories = np.logical_or(
-                dones, done_trajectories)
-            cumulative_rewards += reward * (1 - done_trajectories)
-        return cumulative_rewards
-
-    def build(self):
-        logger.debug("Building policy.")
-        pass
-
-    @property
-    def sampling_params(self):
-        if self.action_space.is_bounded():
-            mean = (self.action_space.high + self.action_space.low) / 2.0
-            stddev = self.action_space.high - self.action_space.low
-            lower_bound = self.action_space.low
-            upper_bound = self.action_space.high
-        else:
-            # For large enough bounds, the truncated normal dist. converges to a standard normal dist.
-            # https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.truncnorm.html#scipy.stats.truncnorm
-            lower_bound = -100
-            upper_bound = 100
-            mean = 0.0
-            stddev = 200
-        return lower_bound, upper_bound, mean, stddev
-
-    def pets_objective(self, cumulative_rewards):
-        rewards_per_sample = cumulative_rewards.reshape((self.particles, self.n_samples))
-        return np.mean(rewards_per_sample, axis=0)
-
-    def pets_with_exploration_bonus(self, cumulative_rewards):
-        rewards_per_sample_per_net = cumulative_rewards.reshape((5, -1, self.n_samples))
-        particle_mean = rewards_per_sample_per_net.mean(axis=1)
-        epistemic = particle_mean.std(axis=0)
-        return self.pets_objective(cumulative_rewards) + epistemic
+        return best_so_far

--- a/simba/policies/mpc_policy.py
+++ b/simba/policies/mpc_policy.py
@@ -1,0 +1,70 @@
+import tensorflow as tf
+from gym import spaces as spaces
+from simba.policies.policy import PolicyBase
+from simba.infrastructure.logging_utils import logger
+
+
+class MpcPolicy(PolicyBase):
+    def __init__(self,
+                 model,
+                 environment,
+                 horizon,
+                 objective,
+                 n_samples,
+                 particles):
+        super().__init__()
+        self.model = model
+        self.reward = environment.get_reward
+        self.action_space = environment.action_space
+        assert isinstance(self.action_space, spaces.Box), "Expecting only box as action space."
+        self.horizon = horizon
+        self.objective = self.pets_objective
+        self.n_samples = n_samples
+        self.particles = particles
+
+    def generate_action(self, state):
+        raise NotImplementedError
+
+    def compute_cumulative_rewards(self, trajectories, action_sequences):
+        cumulative_rewards = tf.zeros((trajectories.shape[0],))
+        done_trajectories = tf.zeros((trajectories.shape[0]), dtype=bool)
+        horizon = trajectories.shape[1]
+        for t in range(horizon - 1):
+            s_t = trajectories[:, t, ...]
+            s_t_1 = trajectories[:, t + 1, ...]
+            a_t = action_sequences[:, t, ...]
+            reward, dones = self.reward(s_t, a_t, s_t_1)
+            done_trajectories = tf.logical_or(
+                dones, done_trajectories)
+            cumulative_rewards += reward * (1.0 - tf.cast(done_trajectories, dtype=tf.float32))
+        return cumulative_rewards
+
+    def build(self):
+        logger.debug("Building policy.")
+        pass
+
+    @property
+    def sampling_params(self):
+        if self.action_space.is_bounded():
+            mean = (self.action_space.high + self.action_space.low) / 2.0
+            stddev = (self.action_space.high - self.action_space.low) / 2.0
+            lower_bound = self.action_space.low
+            upper_bound = self.action_space.high
+        else:
+            # For large enough bounds, the truncated normal dist. converges to a standard normal dist.
+            # https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.truncnorm.html#scipy.stats.truncnorm
+            lower_bound = -100
+            upper_bound = 100
+            mean = 0.0
+            stddev = 100
+        return lower_bound, upper_bound, mean, stddev
+
+    def pets_objective(self, cumulative_rewards):
+        rewards_per_sample = tf.reshape(cumulative_rewards, (self.particles, self.n_samples))
+        return tf.reduce_mean(rewards_per_sample, axis=0)
+
+    def pets_with_exploration_bonus(self, cumulative_rewards):
+        rewards_per_sample_per_net = cumulative_rewards.reshape((5, -1, self.n_samples))
+        particle_mean = rewards_per_sample_per_net.mean(axis=1)
+        epistemic = particle_mean.std(axis=0)
+        return self.pets_objective(cumulative_rewards) + epistemic

--- a/simba/policies/mppi_mpc.py
+++ b/simba/policies/mppi_mpc.py
@@ -1,0 +1,49 @@
+import tensorflow as tf
+from simba.policies.mpc_policy import MpcPolicy
+from simba.infrastructure.logging_utils import logger
+
+
+class MppiMpc(MpcPolicy):
+    def __init__(self,
+                 model,
+                 environment,
+                 horizon,
+                 objective,
+                 n_samples,
+                 particles):
+        super().__init__(
+            model,
+            environment,
+            horizon,
+            objective,
+            n_samples,
+            particles
+        )
+
+    def generate_action(self, state):
+        return self.do_generate_action(tf.constant(state, dtype=tf.float32)).numpy()
+
+    @tf.function
+    def do_generate_action(self, state):
+        lb, ub, mu, sigma = self.sampling_params
+        action_dim = self.action_space.shape[0]
+        mu = tf.broadcast_to(mu, (self.horizon, action_dim))
+        sigma = tf.broadcast_to(sigma, (self.horizon, action_dim))
+        action_sequences = tf.random.normal(
+            shape=(self.n_samples, self.horizon, action_dim),
+            mean=mu, stddev=sigma
+        )
+        action_sequences = tf.clip_by_value(action_sequences, lb, ub)
+        action_sequences_batch = tf.tile(
+            action_sequences, (self.particles, 1, 1)
+        )
+        trajectories = self.model.unfold_sequences(
+            tf.broadcast_to(state, (action_sequences_batch.shape[0], state.shape[0])), action_sequences_batch
+        )
+        cumulative_rewards = self.compute_cumulative_rewards(trajectories, action_sequences_batch)
+        returns = self.objective(cumulative_rewards)
+        scores = tf.exp(5.0 * (returns - tf.reduce_max(returns, axis=0)))
+        weighted_action_sequences = tf.expand_dims(scores, axis=1) * action_sequences[:, 0, ...]
+        return tf.reduce_sum(weighted_action_sequences, axis=0) / tf.reduce_sum(scores + 1e-5, axis=0)
+
+

--- a/simba/policies/random_mpc.py
+++ b/simba/policies/random_mpc.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from simba.policies.policy import PolicyBase
 from simba.infrastructure.logging_utils import logger
 

--- a/simba/policies/random_shooting_mpc.py
+++ b/simba/policies/random_shooting_mpc.py
@@ -1,0 +1,39 @@
+import tensorflow as tf
+from simba.policies.mpc_policy import MpcPolicy
+from simba.infrastructure.logging_utils import logger
+
+
+class RandomShootingMpc(MpcPolicy):
+    def __init__(self,
+                 model,
+                 environment,
+                 horizon,
+                 objective,
+                 n_samples,
+                 particles):
+        super().__init__(
+            model,
+            environment,
+            horizon,
+            objective,
+            n_samples,
+            particles
+        )
+
+    def generate_action(self, state):
+        return self.do_generate_action(tf.constant(state, dtype=tf.float32)).numpy()
+
+    @tf.function
+    def do_generate_action(self, state):
+        lb, ub, mu, sigma = self.sampling_params
+        action_sequences = tf.random.uniform(lb, ub, (self.n_samples, self.horizon, self.action_space.shape[0]))
+        action_sequences_batches = tf.tile(action_sequences, (self.particles, 1, 1))
+        trajectories = self.model.simulate_trajectories(
+            tf.broadcast_to(state, (action_sequences_batches.shape[0], state.shape[0])), action_sequences_batches
+        )
+        cumulative_rewards = self.compute_cumulative_rewards(trajectories, action_sequences_batches)
+        scores = self.objective(cumulative_rewards)
+        best_trajectory_id = tf.argmax(scores)
+        return action_sequences[best_trajectory_id, 0, :]
+
+


### PR DESCRIPTION
Changes:
1. Scale features parameter in agent config
2. Added TF implementations of random shooting and MPPI (not sure about mppi)
3. Replay buffer noise observations option
4. Action repeat parameter added to sample trajectories.
5. Unified replay buffer data sampling functions signature (return obs, rews, etc at the same order)
6. Safety gym experimental np reward
7. Grad clipping with built in keras functionality instead of manually.
8. Created a base class for mpc policies