### PR TITLE
Change of loss function to negative log-likelihood instead of mse

### DIFF
--- a/simba/models/mlp_ensemble.py
+++ b/simba/models/mlp_ensemble.py
@@ -63,9 +63,8 @@ class GaussianDistMlp(tf.keras.Model):
 
 @tf.function
 def negative_log_likelihood(y_true, mu, var):
-    # return 0.5 * tf.reduce_mean(tf.math.log(2.0 * np.pi * var)) + \
-    #        0.5 * tf.reduce_mean(tf.math.divide(tf.square(mu - y_true), var))
-    return 0.5 * tf.reduce_sum(tf.reduce_mean(tf.square(mu - y_true), axis=0))
+    return 0.5 * tf.reduce_mean(tf.math.log(2.0 * np.pi * var)) + \
+           0.5 * tf.reduce_mean(tf.math.divide(tf.square(mu - y_true), var))
 
 
 class MlpEnsemble(tf.Module):


### PR DESCRIPTION
Negative log-likelihood with mean and variance predictions enables sampling from a stochastic transition model.

Here's a benchmark on the  ```Reacher7DOF``` environment:

![objective_epochs](https://user-images.githubusercontent.com/29047534/81501101-becd3e80-92d6-11ea-9b00-9c11357046a4.png)

Where the red plot is the training rl objective **using** the negative log-likelihood as loss